### PR TITLE
Always parse day_of_week to int

### DIFF
--- a/resources/js/components/Gmap.vue
+++ b/resources/js/components/Gmap.vue
@@ -151,7 +151,7 @@ export default {
                 // If there aren't special opening hours, get the default opening hours
                 if (!upcomingDay || upcomingDay === 'undefined') {
                     dayNumber = dayNumber + 1 !== 7 ? dayNumber + 1 : 0
-                    upcomingDay = retailer.times.find((time) => time.attribute_code == 'opening_hours' && time.day_of_week == dayNumber)
+                    upcomingDay = retailer.times.find((time) => time.attribute_code == 'opening_hours' && parseInt(time.day_of_week) == dayNumber)
                 }
             }
 


### PR DESCRIPTION
Always parse day_of_week to int, because it is a string when using graphql to get the retailers.