### PR TITLE
Fix: Re-add times to the frontend.retailers

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ use Rapidez\SmileStoreLocator\Models\Retailer;
 $baseUrl = Rapidez::config('store_locator/seo/base_url', 'stores');
 
 Route::get($baseUrl, function () {
-    config(['frontend.retailers' => Retailer::with('times')->get()->makeHidden(['times'])->append(['opening_time', 'closing_time', 'upcoming_opening_time'])]);
+    config(['frontend.retailers' => Retailer::with('times')->get()->append(['opening_time', 'closing_time', 'upcoming_opening_time'])]);
     config(['frontend.day_names' => collect(Carbon::getDays())->map(function ($day, $index) {
         return ucfirst(Carbon::create(Carbon::getDays()[$index])->dayName);
     })]);

--- a/src/Models/Times.php
+++ b/src/Models/Times.php
@@ -22,6 +22,11 @@ class Times extends Model
 
     protected $fillable = [];
 
+    protected $hidden = [
+        'display_from_date',
+        'display_to_date',
+    ];
+    
     protected static function booted()
     {
         static::addGlobalScope('only-active-times', function (Builder $builder) {
@@ -36,7 +41,6 @@ class Times extends Model
                     $query->whereNull('date')
                           ->orWhere('date', '>=', Carbon::now()->toDateString());
                 });
-                $builder->orderBy('date');
             }
 
             $builder->orderBy('date');

--- a/src/Models/Times.php
+++ b/src/Models/Times.php
@@ -26,7 +26,7 @@ class Times extends Model
         'display_from_date',
         'display_to_date',
     ];
-    
+
     protected static function booted()
     {
         static::addGlobalScope('only-active-times', function (Builder $builder) {


### PR DESCRIPTION
Times is still being used to display the opening times of the week and future special opening times
https://github.com/rapidez/smile-store-locator/blob/master/resources/views/overview.blade.php#L129