### PR TITLE
use import instead of require

### DIFF
--- a/resources/js/maps.js
+++ b/resources/js/maps.js
@@ -8,4 +8,4 @@ Vue.use(GmapVue, {
     installComponents: true
 })
 
-Vue.component('gmap', require('./components/Gmap.vue').default)
+Vue.component('gmap', () => import('./components/Gmap.vue'))


### PR DESCRIPTION
Both Webpack and Vite support import functions, so this is a backwards compatible change