### PR TITLE
Heroicons v2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "illuminate/database": "^9.0",
         "illuminate/support": "^9.0",
         "illuminate/view": "^9.0",
-        "rapidez/core": "~0.55"
+        "rapidez/core": "~0.55",
+        "blade-ui-kit/blade-heroicons": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.3",

--- a/resources/views/overview.blade.php
+++ b/resources/views/overview.blade.php
@@ -29,7 +29,7 @@
                     </gmap-autocomplete>
 
                     <a href="#" v-on:click.prevent="currentLocation" class="flex items-center text-primary mb-5 hover:underline">
-                        <x-heroicon-s-location-marker class="h-4 w-4 mr-1"/>
+                        <x-heroicon-s-map-pin class="h-4 w-4 mr-1"/>
                         @lang('Use my location')
                     </a>
 


### PR DESCRIPTION
In https://github.com/rapidez/core/pull/304, I updated Heroicons to version 2. In the update, some icons have changed, so this should also be updated in the rapidez/smile-store-locator package.