### PR TITLE
Fixed opening time being today if special closed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.0",
-        "rapidez/core": "~0.55|^1.0|^2.0|^3.0",
+        "rapidez/core": "~0.55|^1.0|^2.0|^3.0|^4.0",
         "blade-ui-kit/blade-heroicons": "^2.0"
     },
     "require-dev": {

--- a/src/Models/Retailer.php
+++ b/src/Models/Retailer.php
@@ -170,8 +170,8 @@ class Retailer extends Model
         }
 
         $closestOpening = $this->times->sortBy('start_time')
-            ->firstWhere(fn ($time) => $time->start_time->isFuture());
+            ->firstWhere(fn ($time) => !$time->start_time->isToday() && $time->start_time->isFuture());
 
-        return $closestOpening->start_time;
+        return $closestOpening?->start_time;
     }
 }

--- a/tests/Unit/UpcomingOpeningTimeTest.php
+++ b/tests/Unit/UpcomingOpeningTimeTest.php
@@ -158,4 +158,46 @@ class UpcomingOpeningTimeTest extends TestCase
 
         $this->assertEquals(Carbon::now()->setTime(9, 0)->addDay(), $retailer->upcoming_opening);
     }
+
+    public function testSpecialDateClosedRetailerSelectsNextDay()
+    {
+        $retailer = Retailer::make()
+            ->setRelation(
+                'times',
+                Times::hydrate([
+                    [
+                        'attribute_code'    => 'opening_hours',
+                        'day_of_week'       => today()->dayOfWeek,
+                        'date'              => null,
+                        'start_time'        => '1970-01-01 15:00:00',
+                        'end_time'          => '1970-01-01 18:00:00',
+                        'description'       => null,
+                        'display_from_date' => null,
+                        'display_to_date'   => null,
+                    ],
+                    [
+                        'attribute_code'    => 'opening_hours',
+                        'day_of_week'       => today()->addDay()->dayOfWeek,
+                        'date'              => null,
+                        'start_time'        => '1970-01-01 16:00:00',
+                        'end_time'          => '1970-01-01 18:00:00',
+                        'description'       => null,
+                        'display_from_date' => null,
+                        'display_to_date'   => null,
+                    ],
+                    [
+                        'attribute_code'    => 'special_opening_hours',
+                        'day_of_week'       => null,
+                        'date'              => Carbon::now()->format('Y-m-d'),
+                        'start_time'        => '1970-01-01 00:00:00',
+                        'end_time'          => '1970-01-01 00:00:00',
+                        'description'       => null,
+                        'display_from_date' => Carbon::now()->subDays(2)->format('Y-m-d'),
+                        'display_to_date'   => Carbon::now()->addDays(2)->format('Y-m-d'),
+                    ],
+                ])
+            );
+
+        $this->assertEquals(Carbon::now()->addDay()->setTime(16,0,0), $retailer->upcoming_opening);
+    }
 }

--- a/tests/Unit/UpcomingOpeningTimeTest.php
+++ b/tests/Unit/UpcomingOpeningTimeTest.php
@@ -198,6 +198,6 @@ class UpcomingOpeningTimeTest extends TestCase
                 ])
             );
 
-        $this->assertEquals(Carbon::now()->addDay()->setTime(16,0,0), $retailer->upcoming_opening);
+        $this->assertEquals(Carbon::now()->addDay()->setTime(16, 0, 0), $retailer->upcoming_opening);
     }
 }


### PR DESCRIPTION
This PR aims to fix an issue that occurs when a special opening hour determines the shop to be closed today.
If that is the case it will fall back to the $closestOpening, which does not exclude today from the search.

Thus if there is an opening time today (e.g. 09:00), being overridden by a special opening time closing the shop today, it will say "Closed, opening at: 09:00"